### PR TITLE
[Bug] Query String should be UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## pending
+
+  * Change query string parameter format from "s", to "o", this is to 
+    fix problems with dates being passed as query string parameters and
+	not being interpreted as UTC
+
 ## 0.3.3.0
 
   * Add overload to http response to access the internal http state.

--- a/src/SpeakEasy.Specifications/ParameterSpecification.cs
+++ b/src/SpeakEasy.Specifications/ParameterSpecification.cs
@@ -83,7 +83,7 @@ namespace SpeakEasy.Specifications
                 formatted = parameter.ToQueryString(new CommaSeparatedArrayFormatter());
 
             It should_format_as_query_string = () =>
-                formatted.ShouldEqual("name=2013-10-15T14:30:44");
+                formatted.ShouldEqual("name=2013-10-15T14:30:44.0000000");
 
             static Parameter parameter;
 
@@ -94,13 +94,13 @@ namespace SpeakEasy.Specifications
         public class when_converting_to_query_string_with_nullable_date_time
         {
             Establish context = () =>
-                parameter = new Parameter("name", (DateTime?)new DateTime(2013, 10, 15, 14, 30, 44));
+                parameter = new Parameter("name", (DateTime?)new DateTime(2013, 10, 15, 14, 30, 44, DateTimeKind.Utc));
 
             Because of = () =>
                 formatted = parameter.ToQueryString(new CommaSeparatedArrayFormatter());
 
             It should_format_as_query_string = () =>
-                formatted.ShouldEqual("name=2013-10-15T14:30:44");
+                formatted.ShouldEqual("name=2013-10-15T14:30:44.0000000Z");
 
             static Parameter parameter;
 

--- a/src/SpeakEasy/Parameter.cs
+++ b/src/SpeakEasy/Parameter.cs
@@ -46,7 +46,7 @@ namespace SpeakEasy
         {
             if (value is DateTime)
             {
-                return ((DateTime)value).ToString("s", CultureInfo.InvariantCulture);
+                return ((DateTime)value).ToString("o", CultureInfo.InvariantCulture);
             }
 
             var raw = value.ToString();


### PR DESCRIPTION
This changes the default query string format for dates to use the .NET "o"
format, which is ISO 8601.
