### PR TITLE
[Bug] Additional segments not being used as params

### DIFF
--- a/src/SpeakEasy.Specifications/HttpClientSpecification.cs
+++ b/src/SpeakEasy.Specifications/HttpClientSpecification.cs
@@ -116,10 +116,13 @@ namespace SpeakEasy.Specifications
         public class when_posting_with_body_and_segments : with_client
         {
             Because of = () =>
-                Subject.Post(new { Id = "body" }, "company/:id", new { Id = "segments" });
+                Subject.Post(new { Id = "body" }, "company/:id", new { Id = "segments", moreGarbage = true });
 
             It should_use_segments = () =>
                 The<IRequestRunner>().WasToldTo(r => r.RunAsync(Param<PostRequest>.Matches(p => p.Resource.Path == "http://example.com/company/segments")));
+
+            It should_add_extra_segment_properties_as_parameters = () =>
+                The<IRequestRunner>().WasToldTo(r => r.RunAsync(Param<PostRequest>.Matches(p => p.Resource.HasParameter("moreGarbage"))));
         }
 
         [Subject(typeof(HttpClient))]
@@ -192,10 +195,26 @@ namespace SpeakEasy.Specifications
         public class when_putting_with_body_and_segments : with_client
         {
             Because of = () =>
-                Subject.Put(new { Id = "body" }, "company/:id", new { Id = "segments" });
+                Subject.Put(new { Id = "body" }, "company/:id", new { Id = "segments", moreGarbage = true });
 
             It should_use_segments = () =>
                 The<IRequestRunner>().WasToldTo(r => r.RunAsync(Param<PutRequest>.Matches(p => p.Resource.Path == "http://example.com/company/segments")));
+
+            It should_add_extra_segment_properties_as_parameters = () =>
+                The<IRequestRunner>().WasToldTo(r => r.RunAsync(Param<PutRequest>.Matches(p => p.Resource.HasParameter("moreGarbage"))));
+        }
+
+        [Subject(typeof(HttpClient))]
+        public class when_patching_with_body_and_segments : with_client
+        {
+            Because of = () =>
+                Subject.Patch(new { Id = "body" }, "company/:id", new { Id = "segments", moreGarbage = true });
+
+            It should_use_segments = () =>
+                The<IRequestRunner>().WasToldTo(r => r.RunAsync(Param<PatchRequest>.Matches(p => p.Resource.Path == "http://example.com/company/segments")));
+
+            It should_add_extra_segment_properties_as_parameters = () =>
+                The<IRequestRunner>().WasToldTo(r => r.RunAsync(Param<PatchRequest>.Matches(p => p.Resource.HasParameter("moreGarbage"))));
         }
 
         [Subject(typeof(HttpClient))]

--- a/src/SpeakEasy/HttpClient.cs
+++ b/src/SpeakEasy/HttpClient.cs
@@ -161,7 +161,7 @@ namespace SpeakEasy
 
         public Task<IHttpResponse> PostAsync(object body, string relativeUrl, object segments = null)
         {
-            var merged = BuildRelativeResource(relativeUrl, segments ?? body, false);
+            var merged = BuildRelativeResource(relativeUrl, segments ?? body, segments != null);
             var request = new PostRequest(merged, new ObjectRequestBody(body));
             return RunAsync(request);
         }
@@ -187,7 +187,7 @@ namespace SpeakEasy
 
         public Task<IHttpResponse> PutAsync(object body, string relativeUrl, object segments = null)
         {
-            var merged = BuildRelativeResource(relativeUrl, segments ?? body, false);
+            var merged = BuildRelativeResource(relativeUrl, segments ?? body, segments != null);
             var request = new PutRequest(merged, new ObjectRequestBody(body));
             return RunAsync(request);
         }
@@ -213,7 +213,7 @@ namespace SpeakEasy
 
         public Task<IHttpResponse> PatchAsync(object body, string relativeUrl, object segments = null)
         {
-            var merged = BuildRelativeResource(relativeUrl, segments ?? body, false);
+            var merged = BuildRelativeResource(relativeUrl, segments ?? body, segments != null);
             var request = new PatchRequest(merged, new ObjectRequestBody(body));
             return RunAsync(request);
         }
@@ -232,7 +232,7 @@ namespace SpeakEasy
 
         public Task<IHttpResponse> PatchAsync(IFile[] files, string relativeUrl, object segments = null)
         {
-            var merged = BuildRelativeResource(relativeUrl, segments, false);
+            var merged = BuildRelativeResource(relativeUrl, segments);
             var request = new PatchRequest(merged, new FileUploadBody(merged, files));
             return RunAsync(request);
         }


### PR DESCRIPTION
Additional segments should be useds as query params when not merged into a
resource, with the exception of when a body is given on PUT/POST/PATCH.
