### PR TITLE
[Feature] Better Query Parameter Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## PENDING
+
+  * When making a POST/PUT/PATCH with an object body and segments then
+    extra segment values which do not merge into the URL will be added
+	as query string parameters.
+
 ## 0.3.5.0
 
   * Fix a bug with query params not being added to a resource when a body

--- a/src/SpeakEasy.IntegrationTests/BasicHttpMethods.cs
+++ b/src/SpeakEasy.IntegrationTests/BasicHttpMethods.cs
@@ -217,5 +217,14 @@ namespace SpeakEasy.IntegrationTests
 
             Assert.That(message, Is.EqualTo("titles cannot start with 'bad'"));
         }
+
+        [Test]
+        public void ShouldUseAdditionalSegmentsAsQueryParamsWhenBodySpecified()
+        {
+            var success = client.Put(new { }, "products/:id/reservations", new { id = 1, priceIncrease = 500 })
+                .Is(HttpStatusCode.Created);
+
+            Assert.That(success);
+        }
     }
 }

--- a/src/SpeakEasy.IntegrationTests/Controllers/ReservationsController.cs
+++ b/src/SpeakEasy.IntegrationTests/Controllers/ReservationsController.cs
@@ -15,5 +15,15 @@ namespace SpeakEasy.IntegrationTests.Controllers
 
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         }
+
+        public HttpResponseMessage Put(int productId, int priceIncrease)
+        {
+            if (priceIncrease > 100)
+            {
+                return new HttpResponseMessage(HttpStatusCode.Created);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.BadRequest);
+        }
     }
 }

--- a/src/SpeakEasy.Specifications/FileUploadBodySpecification.cs
+++ b/src/SpeakEasy.Specifications/FileUploadBodySpecification.cs
@@ -6,6 +6,13 @@ namespace SpeakEasy.Specifications
     public class FileUploadBodySpecification
     {
         [Subject(typeof(FileUploadBody))]
+        public class in_general : with_file_upload_body
+        {
+            It should_consume_resource = () =>
+                body.ConsumesResourceParameters.ShouldBeTrue();
+        }
+
+        [Subject(typeof(FileUploadBody))]
         public class when_serializing : with_file_upload_body
         {
             Because of = () =>

--- a/src/SpeakEasy.Specifications/PostRequestSpecification.cs
+++ b/src/SpeakEasy.Specifications/PostRequestSpecification.cs
@@ -1,5 +1,4 @@
-﻿using System.Net;
-using Machine.Fakes;
+﻿using Machine.Fakes;
 using Machine.Specifications;
 
 namespace SpeakEasy.Specifications
@@ -14,6 +13,40 @@ namespace SpeakEasy.Specifications
 
             It should_have_null_body = () =>
                 request.Body.ShouldBeOfType<PostRequestBody>();
+
+            static PostRequest request;
+        }
+
+        [Subject(typeof(PostRequest))]
+        public class when_building_request_url_with_object_body
+        {
+            Establish context = () =>
+            {
+                var resource = new Resource("http://example.com/companies");
+                resource.AddParameter("makemoney", "allday");
+
+                request = new PostRequest(resource, new ObjectRequestBody(new { }));
+            };
+
+            It should_generate_query_params = () =>
+                request.BuildRequestUrl(new CommaSeparatedArrayFormatter()).ShouldEqual("http://example.com/companies?makemoney=allday");
+
+            static PostRequest request;
+        }
+
+        [Subject(typeof(PostRequest))]
+        public class when_building_request_url_with_post_request_body
+        {
+            Establish context = () =>
+            {
+                var resource = new Resource("http://example.com/companies");
+                resource.AddParameter("makemoney", "allday");
+
+                request = new PostRequest(resource, new PostRequestBody(new Resource("foo")));
+            };
+
+            It should_not_generate_query_params = () =>
+                request.BuildRequestUrl(new CommaSeparatedArrayFormatter()).ShouldEqual("http://example.com/companies");
 
             static PostRequest request;
         }

--- a/src/SpeakEasy/FileUploadBody.cs
+++ b/src/SpeakEasy/FileUploadBody.cs
@@ -12,6 +12,11 @@ namespace SpeakEasy
             this.files = files;
         }
 
+        public bool ConsumesResourceParameters
+        {
+            get { return true; }
+        }
+
         public ISerializableBody Serialize(ITransmissionSettings transmissionSettings, IArrayFormatter arrayFormatter)
         {
             return new MultipartMimeDocumentBody(resource, files);

--- a/src/SpeakEasy/GetLikeRequest.cs
+++ b/src/SpeakEasy/GetLikeRequest.cs
@@ -7,17 +7,5 @@ namespace SpeakEasy
         {
 
         }
-
-        public override string BuildRequestUrl(IArrayFormatter arrayFormatter)
-        {
-            if (!Resource.HasParameters)
-            {
-                return Resource.Path;
-            }
-
-            var queryString = Resource.GetEncodedParameters(arrayFormatter);
-
-            return string.Concat(Resource.Path, "?", queryString);
-        }
     }
 }

--- a/src/SpeakEasy/HttpRequest.cs
+++ b/src/SpeakEasy/HttpRequest.cs
@@ -56,7 +56,17 @@ namespace SpeakEasy
             headers.Add(new Header(name, value));
         }
 
-        public abstract string BuildRequestUrl(IArrayFormatter arrayFormatter);
+        public string BuildRequestUrl(IArrayFormatter arrayFormatter)
+        {
+            if (!Resource.HasParameters || Body.ConsumesResourceParameters)
+            {
+                return Resource.Path;
+            }
+
+            var queryString = Resource.GetEncodedParameters(arrayFormatter);
+
+            return string.Concat(Resource.Path, "?", queryString);
+        }
 
         public abstract override string ToString();
     }

--- a/src/SpeakEasy/IRequestBody.cs
+++ b/src/SpeakEasy/IRequestBody.cs
@@ -8,6 +8,13 @@ namespace SpeakEasy
     public interface IRequestBody
     {
         /// <summary>
+        /// Indicates whether or not this request body will use the resource parameters when serializing
+        /// the request body. This is used to indicate whether or not the request can use the resource
+        /// parameters for something else (namely query parameters).
+        /// </summary>
+        bool ConsumesResourceParameters { get; }
+
+        /// <summary>
         /// Serializes the request body
         /// </summary>
         /// <param name="transmissionSettings">The transmission settings</param>

--- a/src/SpeakEasy/NullRequestBody.cs
+++ b/src/SpeakEasy/NullRequestBody.cs
@@ -2,6 +2,11 @@ namespace SpeakEasy
 {
     internal class NullRequestBody : IRequestBody
     {
+        public bool ConsumesResourceParameters
+        {
+            get { return false; }
+        }
+
         public ISerializableBody Serialize(ITransmissionSettings transmissionSettings, IArrayFormatter arrayFormatter)
         {
             return new NullSerializableBody(transmissionSettings);

--- a/src/SpeakEasy/ObjectRequestBody.cs
+++ b/src/SpeakEasy/ObjectRequestBody.cs
@@ -16,6 +16,11 @@ namespace SpeakEasy
             get { return string.Empty; }
         }
 
+        public bool ConsumesResourceParameters
+        {
+            get { return false; }
+        }
+
         public ISerializableBody Serialize(ITransmissionSettings transmissionSettings, IArrayFormatter arrayFormatter)
         {
             var serialized = transmissionSettings.Serialize(body);

--- a/src/SpeakEasy/PostLikeRequest.cs
+++ b/src/SpeakEasy/PostLikeRequest.cs
@@ -11,10 +11,5 @@ namespace SpeakEasy
             : base(resource, body)
         {
         }
-
-        public override string BuildRequestUrl(IArrayFormatter arrayFormatter)
-        {
-            return Resource.Path;
-        }
     }
 }

--- a/src/SpeakEasy/PostRequestBody.cs
+++ b/src/SpeakEasy/PostRequestBody.cs
@@ -11,6 +11,11 @@ namespace SpeakEasy
             this.resource = resource;
         }
 
+        public bool ConsumesResourceParameters
+        {
+            get { return true; }
+        }
+
         public ISerializableBody Serialize(ITransmissionSettings transmissionSettings, IArrayFormatter arrayFormatter)
         {
             if (resource.HasParameters)


### PR DESCRIPTION
When making a PUT/POST/PATCH request with a body then additional segments
will be used as query parameters, otherwise they will be used as form
data.
