### PR TITLE
[Feature] Fix gitversion pre-release versioning

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,11 +15,11 @@ install:
 dotnet_csproj:
   patch: true
   file: 'src\**\*.csproj'
-  version: $(GitVersion_NuGetVersion)
-  package_version: $(GitVersion_NuGetVersion)
-  assembly_version: $(GitVersion_NuGetVersion)
-  file_version: $(GitVersion_NuGetVersion)
-  informational_version: $(GitVersion_NuGetVersion)
+  version: '%GitVersion_MajorMinorPatch%'
+  package_version: '%GitVersion_NuGetVersion%'
+  assembly_version: '%GitVersion_MajorMinorPatch%'
+  file_version: '%GitVersion_MajorMinorPatch%'
+  informational_version: '%GitVersion_MajorMinorPatch%'
 
 build:
   parallel: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,11 +15,11 @@ install:
 dotnet_csproj:
   patch: true
   file: 'src\**\*.csproj'
-  version: '%GitVersion_MajorMinorPatch%'
-  package_version: '%GitVersion_NuGetVersion%'
-  assembly_version: '%GitVersion_MajorMinorPatch%'
-  file_version: '%GitVersion_MajorMinorPatch%'
-  informational_version: '%GitVersion_MajorMinorPatch%'
+  version: $(GitVersion_NuGetVersion)
+  package_version: $(GitVersion_NuGetVersion)
+  assembly_version: $(GitVersion_MajorMinorPatch)
+  file_version: $(GitVersion_MajorMinorPatch)
+  informational_version: $(GitVersion_MajorMinorPatch)
 
 build:
   parallel: true

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,8 @@ Ankh.NoLoad
 _ReSharper*/
 *.resharper
 [Tt]est[Rr]esult*
-src/.vs/
 .vscode/
+.vs/
 
 #Subversion files
 .svn

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,9 @@
 mode: ContinuousDelivery
 next-version: 1.0.0
 branches:
+  master:
+    regex: master
+    tag: ''
   pull-request:
     regex: (pull|pull\-requests|pr)[/-]
     tag: pre

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,2 @@
 mode: ContinuousDelivery
 next-version: 1.0.0
-branches:
-  pull-request:
-    tag: pr

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,6 @@
 mode: ContinuousDelivery
 next-version: 1.0.0
-branches: {}
-ignore:
-  sha: []
+branches:
+  pull-request:
+    regex: (pull|pull\-requests|pr)[/-]
+    tag: pre

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,4 +2,4 @@ mode: ContinuousDelivery
 next-version: 1.0.0
 branches:
   pull-request:
-    tag: pre
+    tag: pr

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,9 +1,5 @@
 mode: ContinuousDelivery
 next-version: 1.0.0
 branches:
-  master:
-    regex: master
-    tag: ''
   pull-request:
-    regex: (pull|pull\-requests|pr)[/-]
     tag: pre

--- a/src/SpeakEasy/SpeakEasy.csproj
+++ b/src/SpeakEasy/SpeakEasy.csproj
@@ -12,6 +12,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
@jonnii Take a look. The trick is that you have to have a `Version` attribute in the csproj before overriding it with gitversion. Also the assembly versioning won't handle the Semver versioning, so you have to use major/minor/patch. You can use the semver version for the package itself however.