### PR TITLE
Properly escape url params

### DIFF
--- a/src/SpeakEasy.Specifications/ParameterSpecs.cs
+++ b/src/SpeakEasy.Specifications/ParameterSpecs.cs
@@ -91,5 +91,17 @@ namespace SpeakEasy.Specifications
             It should_not_have_value = () =>
                 parameter.HasValue.ShouldBeFalse();
         }
+
+        class when_converting_values_containing_slashes_and_ampersands
+        {
+            Establish context = () =>
+                parameter = new Parameter("name", "value/this&that");
+
+            Because of = () =>
+                formatted = parameter.ToQueryString(new CommaSeparatedArrayFormatter());
+
+            It should_properly_escape_special_characters = () =>
+                formatted.ShouldEqual("name=value%2Fthis%26that");
+        }
     }
 }

--- a/src/SpeakEasy/Parameter.cs
+++ b/src/SpeakEasy/Parameter.cs
@@ -43,7 +43,7 @@ namespace SpeakEasy
 
             var raw = value.ToString();
 
-            return Uri.EscapeUriString(raw);
+            return Uri.EscapeDataString(raw);
         }
     }
 }


### PR DESCRIPTION
`Uri.EscapeUriString` is weird. It basically ignores `/` and `&` and probably others too.