### PR TITLE
Fix query serializer when serializing array values

### DIFF
--- a/src/SpeakEasy.IntegrationTests/SpeakEasy.IntegrationTests.csproj
+++ b/src/SpeakEasy.IntegrationTests/SpeakEasy.IntegrationTests.csproj
@@ -16,14 +16,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
 
     <PackageReference Include="xunit" Version="2.4.1" />
 
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/SpeakEasy.Specifications/DefaultQuerySerializerSpecs.cs
+++ b/src/SpeakEasy.Specifications/DefaultQuerySerializerSpecs.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Machine.Specifications;
 using SpeakEasy.Serializers;
 
@@ -48,6 +49,9 @@ namespace SpeakEasy.Specifications
 
                 It should_format_as_query_string = () =>
                     formatted.ShouldContain("name=3", "name=4", "name=5");
+
+                It should_have_three_values = () =>
+                    formatted.Count().ShouldEqual(3);
             }
         }
 

--- a/src/SpeakEasy.Specifications/SpeakEasy.Specifications.csproj
+++ b/src/SpeakEasy.Specifications/SpeakEasy.Specifications.csproj
@@ -16,9 +16,9 @@
   <ItemGroup>
     <PackageReference Include="Machine.Specifications" Version="1.0.0" />
     <PackageReference Include="Machine.Specifications.Should" Version="1.0.0" />
-    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.10.0" />
+    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.10.1" />
     <PackageReference Include="Machine.Fakes.Moq" Version="2.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
 
     <ProjectReference Include="..\SpeakEasy\SpeakEasy.csproj" />
   </ItemGroup>

--- a/src/SpeakEasy/DefaultQuerySerializer.cs
+++ b/src/SpeakEasy/DefaultQuerySerializer.cs
@@ -40,10 +40,12 @@ namespace SpeakEasy
                     yield return string.Concat(parameter.Name, "=", items);
                 }
             }
+            else
+            {
+                var value = ToQueryStringValue(parameter.Value);
 
-            var value = ToQueryStringValue(parameter.Value);
-
-            yield return string.Concat(parameter.Name, "=", value);
+                yield return string.Concat(parameter.Name, "=", value);
+            }
         }
 
         private string ToQueryStringValue(object value)

--- a/src/SpeakEasy/SpeakEasy.csproj
+++ b/src/SpeakEasy/SpeakEasy.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When serializing arrays, the array values are serialized, but also the array `object` gets 'serialized' too, which just results in a garbage type string.

Also bump Newtonsoft package